### PR TITLE
Fix issue with util.queueMicrotask and cjs loader

### DIFF
--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -167,7 +167,7 @@ module.exports = {
   destroy,
   bodyLength,
   isBuffer,
-  queueMicrotask: global.queueMicrotask ? global.queueMicrotask.bind(global) : (cb => Promise.resolve()
+  queueMicrotask: global.queueMicrotask ? global.queueMicrotask.bind(global) : cb => Promise.resolve()
     .then(cb)
-    .catch(err => setTimeout(() => { throw err }, 0)))
+    .catch(err => setTimeout(() => { throw err }, 0))
 }

--- a/lib/core/util.js
+++ b/lib/core/util.js
@@ -167,7 +167,7 @@ module.exports = {
   destroy,
   bodyLength,
   isBuffer,
-  queueMicrotask: global.queueMicrotask || (cb => Promise.resolve()
+  queueMicrotask: global.queueMicrotask ? global.queueMicrotask.bind(global) : (cb => Promise.resolve()
     .then(cb)
     .catch(err => setTimeout(() => { throw err }, 0)))
 }


### PR DESCRIPTION
👋 all. Thanks for this fantastic lib.
When I require undici inside Electron
and run this code 

```js
require('undici/lib/core/util.js').queueMicrotask(() => console.log('hello'))
```

I get a `Uncaught TypeError: Illegal invocation`
Looks like this is related to how the code is loaded via the cjs/loader

